### PR TITLE
Fix resultcode codec

### DIFF
--- a/libats-messaging-datatype/src/main/scala/com/advancedtelematic/libats/messaging_datatype/DataType.scala
+++ b/libats-messaging-datatype/src/main/scala/com/advancedtelematic/libats/messaging_datatype/DataType.scala
@@ -44,8 +44,6 @@ object DataType {
   case class UpdateId(uuid: UUID) extends UUIDKey
   object UpdateId extends UUIDKeyObj[UpdateId]
 
-  final case class SourceUpdateId(value: String) extends AnyVal
-
   final case class InstallationResult(success: Boolean, code: ResultCode, description: ResultDescription)
 
   final case class EcuInstallationReport(result: InstallationResult, target: Seq[String], rawReport: Option[Array[Byte]] = None)

--- a/libats-messaging-datatype/src/main/scala/com/advancedtelematic/libats/messaging_datatype/Messages.scala
+++ b/libats-messaging-datatype/src/main/scala/com/advancedtelematic/libats/messaging_datatype/Messages.scala
@@ -43,12 +43,13 @@ object MessageCodecs {
   implicit val userCreatedCodec: Codec[UserCreated] = deriveCodec
   implicit val campaignLaunchedCodec: Codec[CampaignLaunched] = deriveCodec
   implicit val packageIdCodec: Codec[PackageId] = deriveCodec
-  implicit val resultCodeCodec: Codec[ResultCode] = deriveCodec
-  implicit val resultDescriptionCodec: Codec[ResultDescription] = deriveCodec
+  implicit val resultCodeEncoder: Encoder[ResultCode] = Encoder.encodeString.contramap(_.value)
+  implicit val resultCodeDecoder: Decoder[ResultCode] = Decoder.decodeString.map(ResultCode)
+  implicit val resultDescriptionEncoder: Encoder[ResultDescription] = Encoder.encodeString.contramap(_.value)
+  implicit val resultDescriptionDecoder: Decoder[ResultDescription] = Decoder.decodeString.map(ResultDescription)
   implicit val installationResultCodec: Codec[InstallationResult] = deriveCodec
   implicit val ecuInstallationReportCodec: Codec[EcuInstallationReport] = deriveCodec
   implicit val updateTypeCodec: Codec[UpdateType] = Codec.codecForEnumeration(UpdateType)
-  implicit val sourceUpdateIdCodec: Codec[SourceUpdateId] = deriveCodec
   implicit val systemInfoCodec: Codec[SystemInfo] = deriveCodec
   implicit val deviceSystemInfoChangedCodec: Codec[DeviceSystemInfoChanged] = deriveCodec
   implicit val ecuAndHardwareIdCodec: Codec[EcuAndHardwareId] = deriveCodec
@@ -93,14 +94,6 @@ object Messages {
     def correlationId: CorrelationId
     def deviceUuid: DeviceId
   }
-
-  final case class DeviceUpdateAssignmentRequested(
-      namespace: Namespace,
-      eventTime: Instant,
-      correlationId: CorrelationId,
-      deviceUuid: DeviceId,
-      sourceUpdateId: SourceUpdateId
-  ) extends DeviceUpdateEvent
 
   final case class DeviceUpdateAssigned(
       namespace: Namespace,

--- a/libats-slick/src/main/scala/com/advancedtelematic/libats/slick/db/SlickEncryptedColumn.scala
+++ b/libats-slick/src/main/scala/com/advancedtelematic/libats/slick/db/SlickEncryptedColumn.scala
@@ -19,7 +19,6 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 
 
 import cats.implicits._
-import scala.util.Try
 
 protected [db] class SlickCrypto(salt: Array[Byte], password: String) {
   private lazy val pbeParameterSpec = new PBEParameterSpec(salt, 1000)
@@ -70,7 +69,7 @@ protected [db] object SlickCrypto {
     val saltV = Validated.condNel(saltBytes.length >= 8, saltBytes, "SlickCrypto: Salt needs to be base64 encoded and 8 bytes or longer")
     val passV = Validated.condNel(password.length >= 64, password, "SlickCrypto: password needs to be 64 chars or longer")
 
-    val slickCryptoV: ValidatedNel[String, SlickCrypto] = (saltV, passV).mapN { (saltbytes, password) =>
+    val slickCryptoV: ValidatedNel[String, SlickCrypto] = (saltV, passV).mapN { (_, password) =>
       new SlickCrypto(saltBytes, password)
     }
 
@@ -84,7 +83,7 @@ object SlickEncryptedColumn {
   import cats.syntax.either._
   import SlickCrypto.configSlickCrypto
 
-  case class EncryptedColumn[T](value: T) extends AnyVal
+  case class EncryptedColumn[T](value: T)
 
   def encryptedColumnJsonMapper[T : ClassTag : Encoder : Decoder]: BaseColumnType[EncryptedColumn[T]] =
     MappedColumnType.base[EncryptedColumn[T], String](


### PR DESCRIPTION
It was encoded as `{"value": <result code> }`, but should just be
encoded as `<result code>` for backwards compatibility

Avoid using AnyVal so that codecs must be specified explicitly and not
using `deriveCodec`, to avoid this issue in the future.

Removed unused message