### PR TITLE
[libats-messaging] add new skipJsonError option

### DIFF
--- a/libats-messaging/src/main/resources/reference.conf
+++ b/libats-messaging/src/main/resources/reference.conf
@@ -5,6 +5,7 @@ messaging {
   mode = "kafka"
   mode = ${?MESSAGING_MODE}
   kafka {
+    skipJsonErrors = true
     groupIdPrefix = ${?KAFKA_GROUP_ID}
     topicSuffix = "dev"
     topicSuffix = ${?KAFKA_TOPIC_SUFFIX}

--- a/libats-messaging/src/main/scala/com/advancedtelematic/libats/messaging/kafka/KafkaClient.scala
+++ b/libats-messaging/src/main/scala/com/advancedtelematic/libats/messaging/kafka/KafkaClient.scala
@@ -97,8 +97,9 @@ object KafkaClient {
       val host = config.getString("messaging.kafka.host")
       val topicFn = topic(config)
       val groupId = config.getString("messaging.kafka.groupIdPrefix") + "-" + topicFn(ml.streamName)
+      val skipJsonErrors = config.getBoolean("messaging.kafka.skipJsonErrors")
 
-      ConsumerSettings(system, new ByteArrayDeserializer, new JsonDeserializer(ml.decoder))
+      ConsumerSettings(system, new ByteArrayDeserializer, new JsonDeserializer(ml.decoder, throwException = ! skipJsonErrors))
         .withBootstrapServers(host)
         .withGroupId(groupId)
         .withClientId(s"consumer-$groupId")


### PR DESCRIPTION
Skips json errors when deserializing kafka messsages, turned on by
default, as it's the current behavior