### PR TITLE
Relax trait requirements for BootMigrations and CheckMigrations

### DIFF
--- a/libats-messaging/src/main/scala/com/advancedtelematic/libats/messaging/MessageListenerSupport.scala
+++ b/libats-messaging/src/main/scala/com/advancedtelematic/libats/messaging/MessageListenerSupport.scala
@@ -20,7 +20,7 @@ trait MessageListenerSupport {
       else
         MsgOperation.logFailed(op)(system.log, system.dispatcher)
 
-    val groupId = if (globalConfig.hasPath("ats.messaging.grouPIdPrefix"))
+    val groupId = if (globalConfig.hasPath("ats.messaging.groupIdPrefix"))
       globalConfig.getString("ats.messaging.groupIdPrefix")
     else
       projectName

--- a/libats-slick/src/main/scala/com/advancedtelematic/libats/slick/db/BootMigrations.scala
+++ b/libats-slick/src/main/scala/com/advancedtelematic/libats/slick/db/BootMigrations.scala
@@ -66,7 +66,9 @@ protected [db] object RunMigrations {
 }
 
 trait CheckMigrations {
-  self: BootApp with DatabaseSupport =>
+  self: BootApp =>
+
+  val dbConfig: Config
 
   private lazy val _log = LoggerFactory.getLogger(this.getClass)
 
@@ -87,11 +89,13 @@ trait CheckMigrations {
 
 
 trait BootMigrations {
-  self: BootApp with DatabaseSupport =>
+  self: BootApp =>
 
   import system.dispatcher
 
   private lazy val _log = LoggerFactory.getLogger(this.getClass)
+
+  val dbConfig: Config
 
   private def migrateIfEnabled: Future[Int] = {
     if (globalConfig.getBoolean("ats.database.migrate"))


### PR DESCRIPTION
Require that a dbConfig is available instead.

This allows api users to use different slick.Database implementations
and still run/check migrations only be requiring a dbConfig