### PR TITLE
Add implicit method toErrorRepr to errors

### DIFF
--- a/libats-http/src/main/scala/com/advancedtelematic/libats/http/ErrorHandler.scala
+++ b/libats-http/src/main/scala/com/advancedtelematic/libats/http/ErrorHandler.scala
@@ -6,120 +6,142 @@
 package com.advancedtelematic.libats.http
 
 import java.util.UUID
-
 import akka.event.LoggingAdapter
-import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.model.StatusCodes.*
 import akka.http.scaladsl.model.{HttpResponse, StatusCode, StatusCodes, Uri}
-import akka.http.scaladsl.server.{Directives, ExceptionHandler, _}
+import akka.http.scaladsl.server.{Directives, ExceptionHandler, *}
 import cats.Show
-import com.advancedtelematic.libats.data.{ErrorCode, ErrorCodes, ErrorRepresentation}
-import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
-import io.circe.syntax._
-import com.advancedtelematic.libats.codecs.CirceUuid._
+import com.advancedtelematic.libats.data.{
+  ErrorCode,
+  ErrorCodes,
+  ErrorRepresentation
+}
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport.*
+import io.circe.syntax.*
+import com.advancedtelematic.libats.codecs.CirceUuid.*
 import io.circe.{DecodingFailure, Json}
-import cats.syntax.option._
-import cats.syntax.show
-import shapeless.{Generic, HNil}
+import cats.syntax.option.*
+import org.slf4j.LoggerFactory
 
 import scala.reflect.ClassTag
 import scala.util.control.NoStackTrace
 import scala.language.existentials
 
 object Errors {
-  import Directives._
-  import ErrorRepresentation._
+  import Directives.*
+  import ErrorRepresentation.*
+
+  private lazy val log = LoggerFactory.getLogger(this.getClass)
 
   abstract class Error(val code: ErrorCode,
                        val responseCode: StatusCode,
                        val msg: String,
                        val cause: Option[Throwable] = None,
-                       val errorId: UUID = UUID.randomUUID()) extends Exception(msg, cause.orNull) with NoStackTrace
+                       val errorId: UUID = UUID.randomUUID())
+      extends Exception(msg, cause.orNull)
+      with NoStackTrace
 
   case class JsonError(code: ErrorCode,
                        responseCode: StatusCode,
                        json: Json,
                        msg: String,
-                       errorId: UUID = UUID.randomUUID()) extends Exception(msg) with NoStackTrace
+                       errorId: UUID = UUID.randomUUID())
+      extends Exception(msg)
+      with NoStackTrace
 
   case class RawError(code: ErrorCode,
                       responseCode: StatusCode,
                       desc: String,
-                      errorId: UUID = UUID.randomUUID()) extends Exception(desc) with NoStackTrace
+                      errorId: UUID = UUID.randomUUID())
+      extends Exception(desc)
+      with NoStackTrace
 
   case class RemoteServiceError(msg: String,
                                 status: StatusCode,
                                 description: Json = Json.Null,
-                                causeCode: ErrorCode = ErrorCodes.RemoteServiceError,
+                                causeCode: ErrorCode =
+                                  ErrorCodes.RemoteServiceError,
                                 cause: Option[ErrorRepresentation] = None,
-                                errorId: UUID = UUID.randomUUID()
-                               ) extends Exception(s"Remote Service Error: $msg") with NoStackTrace
+                                errorId: UUID = UUID.randomUUID())
+      extends Exception(s"Remote Service Error: $msg")
+      with NoStackTrace
 
-  case class MissingEntityId[T](id: T)(implicit ct: ClassTag[T], show: Show[T]) extends
-    Error(ErrorCodes.MissingEntity, StatusCodes.NotFound, s"Missing entity: ${ct.runtimeClass.getSimpleName} ${show.show(id)}")
+  case class MissingEntityId[T](id: T)(implicit ct: ClassTag[T], show: Show[T])
+      extends Error(
+        ErrorCodes.MissingEntity,
+        StatusCodes.NotFound,
+        s"Missing entity: ${ct.runtimeClass.getSimpleName} ${show.show(id)}")
 
-  case class MissingEntity[T]()(implicit ct: ClassTag[T]) extends
-    Error(ErrorCodes.MissingEntity, StatusCodes.NotFound, s"Missing entity: ${ct.runtimeClass.getSimpleName}")
+  case class MissingEntity[T]()(implicit ct: ClassTag[T])
+      extends Error(ErrorCodes.MissingEntity,
+                    StatusCodes.NotFound,
+                    s"Missing entity: ${ct.runtimeClass.getSimpleName}")
 
-  case class EntityAlreadyExists[T]()(implicit ct: ClassTag[T]) extends
-    Error(ErrorCodes.ConflictingEntity, StatusCodes.Conflict, s"Entity already exists: ${ct.runtimeClass.getSimpleName}")
+  case class EntityAlreadyExists[T]()(implicit ct: ClassTag[T])
+      extends Error(ErrorCodes.ConflictingEntity,
+                    StatusCodes.Conflict,
+                    s"Entity already exists: ${ct.runtimeClass.getSimpleName}")
 
-  val TooManyElements = RawError(ErrorCodes.TooManyElements, StatusCodes.InternalServerError, "Too many elements found")
+  val TooManyElements = RawError(ErrorCodes.TooManyElements,
+                                 StatusCodes.InternalServerError,
+                                 "Too many elements found")
 
-  type PF = PartialFunction[Throwable, (StatusCode, ErrorRepresentation)]
+  implicit val rawErrorToRepr: ToErrorRepr[RawError] = e =>
+    ErrorRepresentation(e.code, e.desc, None, e.errorId.some)
 
-  private val onRawError: PF = {
-    case RawError(code, statusCode, desc, uuid) =>
-      statusCode -> ErrorRepresentation(code, desc, None, uuid.some)
-  }
+  implicit val decoderErrorToRepr: ToErrorRepr[DecodingFailure] = df =>
+    ErrorRepresentation(ErrorCodes.InvalidEntity, df.getMessage)
 
-  private[http] val onDecodingError: PF = {
-    case df: DecodingFailure =>
-      StatusCodes.BadRequest -> ErrorRepresentation(ErrorCodes.InvalidEntity, df.getMessage())
-  }
+  implicit val jsonErrorToRepr: ToErrorRepr[JsonError] = je =>
+    ErrorRepresentation(je.code, je.msg, je.json.some, je.errorId.some)
 
-  private val onJsonError: PF = {
-    case JsonError(code, statusCode, json, description, errorId) =>
-      statusCode -> ErrorRepresentation(code, description, json.some, errorId.some)
-  }
+  implicit val onRemoteServiceErrorToRepr: ToErrorRepr[RemoteServiceError] =
+    rse =>
+      ErrorRepresentation(rse.causeCode,
+                          rse.msg,
+                          rse.cause.map(_.asJson),
+                          rse.errorId.some)
 
-  private val onRemoteServiceError: PF = {
-    case RemoteServiceError(msg, _, _, code, cause, errorId) =>
-      StatusCodes.BadGateway -> ErrorRepresentation(code, msg, cause.map(_.asJson), errorId.some)
-  }
-
-  private val onError: PF = {
-    case e : Error =>
-      e.responseCode -> ErrorRepresentation(e.code, e.msg, e.cause.map(_.getMessage.asJson), e.errorId.some)
-  }
-
-  private val onIntegrityViolationError: PF = {
-    case err: java.sql.SQLIntegrityConstraintViolationException if err.getErrorCode == 1062 =>
-      StatusCodes.Conflict -> ErrorRepresentation(ErrorCodes.ConflictingEntity, "Entry already exists")
-  }
+  implicit val onErrorToRepr: ToErrorRepr[Error] = e =>
+    ErrorRepresentation(e.code,
+                        e.msg,
+                        e.cause.map(_.getMessage.asJson),
+                        e.errorId.some)
 
   // Add more handlers here, or use RawError
-  private val toErrorRepresentation: PartialFunction[Throwable, (StatusCode, ErrorRepresentation)] =
-    Seq(
-      onDecodingError,
-      onJsonError,
-      onError,
-      onRemoteServiceError,
-      onIntegrityViolationError,
-      onRawError
-    ).foldLeft(PartialFunction.empty[Throwable, (StatusCode, ErrorRepresentation)])(_ orElse _)
+  private val toErrorRepresentation
+    : PartialFunction[Throwable, (StatusCode, ErrorRepresentation)] = {
+    case e: RawError =>
+      e.responseCode -> e.toErrorRepr
+    case df: DecodingFailure =>
+      StatusCodes.BadRequest -> df.toErrorRepr
+    case je: JsonError =>
+      je.responseCode -> je.toErrorRepr
+    case rse: RemoteServiceError =>
+      StatusCodes.BadGateway -> rse.toErrorRepr
+    case e: Error =>
+      e.responseCode -> e.toErrorRepr
+    case err: java.sql.SQLIntegrityConstraintViolationException
+        if err.getErrorCode == 1062 =>
+      StatusCodes.Conflict -> ErrorRepresentation(ErrorCodes.ConflictingEntity,
+                                                  "Entry already exists")
+  }
 
   val logAndHandleErrors: PartialFunction[Throwable, Route] =
     toErrorRepresentation andThen {
       case (status, errorRepr) =>
-        extractLog { log =>
-          log.error(s"An error occurred. ErrorId: ${errorRepr.errorId} ${errorRepr.asJson.noSpaces}")
-          complete(status -> errorRepr)
-        }
+        log
+          .atError()
+          .addKeyValue("errrorId", errorRepr.errorId.asJson)
+          .addKeyValue("error", errorRepr.asJson)
+          .log("an error occurred")
+
+        complete(status -> errorRepr)
     }
 }
 
 object ErrorHandler {
-  import Directives._
+  import Directives.*
 
   def logError(log: LoggingAdapter, uri: Uri, error: Throwable): UUID = {
     val id = UUID.randomUUID()

--- a/libats-http/src/test/scala/com/advancedtelematic/libats/http/ErrorHandlerSpec.scala
+++ b/libats-http/src/test/scala/com/advancedtelematic/libats/http/ErrorHandlerSpec.scala
@@ -10,6 +10,7 @@ import io.circe.CursorOp.DownField
 import io.circe.DecodingFailure
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import Errors.*
 
 
 class ErrorHandlerSpec extends AnyFunSuite with Matchers with ScalatestRouteTest {
@@ -25,7 +26,7 @@ class ErrorHandlerSpec extends AnyFunSuite with Matchers with ScalatestRouteTest
   }
 
   test("DecodingFailure error handler keeps decoding history") {
-    val (_, errorRepresentation) = Errors.onDecodingError(DecodingFailure("msg", List(DownField("field"))))
+    val errorRepresentation = Errors.decoderErrorToRepr(DecodingFailure("msg", List(DownField("field"))))
     assert(errorRepresentation.description == "DecodingFailure at .field: msg")
   }
 

--- a/libats/src/main/scala/com/advancedtelematic/libats/data/Errors.scala
+++ b/libats/src/main/scala/com/advancedtelematic/libats/data/Errors.scala
@@ -5,8 +5,8 @@
 package com.advancedtelematic.libats.data
 
 import java.util.UUID
-
 import io.circe.{Decoder, Encoder, Json}
+
 
 /**
   * Errors are presented to the user of the core and resolver API as
@@ -27,9 +27,17 @@ object ErrorCodes {
 case class ErrorRepresentation(code: ErrorCode, description: String, cause: Option[Json] = None, errorId: Option[UUID] = Some(UUID.randomUUID()))
 
 object ErrorRepresentation {
-  import io.circe.generic.semiauto._
+  import io.circe.generic.semiauto.*
   implicit val encoderInstance: Encoder[ErrorRepresentation] = deriveEncoder[ErrorRepresentation]
   implicit val decoderInstance: Decoder[ErrorRepresentation] = deriveDecoder[ErrorRepresentation]
+
+  trait ToErrorRepr[T] {
+    def apply(value: T): ErrorRepresentation
+  }
+
+  implicit class ToErrorReprOps[E: ToErrorRepr](value: E) {
+    def toErrorRepr: ErrorRepresentation = implicitly[ToErrorRepr[E]].apply(value)
+  }
 
 }
 


### PR DESCRIPTION
So they can be easily converted to ErrorRepresentation outside libats.

We do this instead of providing `io.circe.Encoder[Error]` as we want to convert all errors to a common format, `ErrorRepresentation`, and providing an `Encoder` to encode `Error => ErrorRepresentation => Json` would work but would be likely to cause confusion.