### PR TITLE
Add configurable Zipkin tracing sample rate

### DIFF
--- a/libats-http-tracing/src/main/resources/reference.conf
+++ b/libats-http-tracing/src/main/resources/reference.conf
@@ -4,5 +4,7 @@ ats {
     enabled = ${?ATS_HTTP_TRACING}
     zipkin_uri = "http://127.0.0.1:9411"
     zipkin_uri = ${?ZIPKIN_URI}
+    sample_rate = 1.0
+    sample_rate = ${?ZIPKIN_SAMPLE_RATE}
   }
 }

--- a/libats-http-tracing/src/main/scala/com/advancedtelematic/libats/http/tracing/Tracing.scala
+++ b/libats-http-tracing/src/main/scala/com/advancedtelematic/libats/http/tracing/Tracing.scala
@@ -40,8 +40,9 @@ object Tracing {
     try {
       if (config.getBoolean("ats.http.tracing.enabled")) {
         val uri = Uri(config.getString("ats.http.tracing.zipkin_uri"))
-        _log.info(s"zipkin tracing enabled to $uri")
-        ZipkinServerRequestTracing(uri, serviceName)
+        val sampleRate = config.getDouble("ats.http.tracing.sample_rate").toFloat
+        _log.info(s"zipkin tracing enabled to $uri with sample rate $sampleRate")
+        ZipkinServerRequestTracing(uri, serviceName, sampleRate)
       } else {
         _log.info("Request tracing disabled in config")
         new NullTracing

--- a/libats-http-tracing/src/main/scala/com/advancedtelematic/libats/http/tracing/ZipkinServerRequestTracing.scala
+++ b/libats-http-tracing/src/main/scala/com/advancedtelematic/libats/http/tracing/ZipkinServerRequestTracing.scala
@@ -5,6 +5,7 @@ import org.apache.pekko.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
 import org.apache.pekko.http.scaladsl.server.Directive1
 import brave.http.{HttpServerAdapter, HttpServerHandler, HttpTracing}
 import brave.propagation.TraceContext
+import brave.sampler.CountingSampler
 import brave.{Span, Tracing => BraveTracing}
 import com.advancedtelematic.libats.http.tracing.Tracing.{PekkoHttpClientTracing, ServerRequestTracing, Tracing}
 import zipkin2.reporter.AsyncReporter
@@ -77,13 +78,15 @@ class ZipkinTracing(httpTracing: HttpTracing) extends Tracing {
 }
 
 object ZipkinServerRequestTracing {
-  def apply(uri: Uri, serviceName: String): ZipkinTracing = {
+  def apply(uri: Uri, serviceName: String, sampleRate: Float = 1.0f): ZipkinTracing = {
     val sender = OkHttpSender.create(uri.toString() + "/api/v2/spans")
     val spanReporter = AsyncReporter.create(sender)
 
     val tracing = BraveTracing.newBuilder
       .localServiceName(serviceName)
-      .spanReporter(spanReporter).build
+      .spanReporter(spanReporter)
+      .sampler(CountingSampler.create(sampleRate))
+      .build
 
     val httpTracing = HttpTracing.newBuilder(tracing).build()
 


### PR DESCRIPTION
Add ZIPKIN_SAMPLE_RATE env var support to libats-http-tracing so services can reduce Zipkin sampling without custom Boot.scala boilerplate.